### PR TITLE
Fix value in path extractor

### DIFF
--- a/src/algorithms/uast_to_bag_paths.py
+++ b/src/algorithms/uast_to_bag_paths.py
@@ -27,7 +27,7 @@ class Uast2BagOfPaths(PickleableLogger):
         """
 
         path_contexts = get_paths(uast, self._max_length, self._max_width)
-        dict_of_paths = Counter(path_contexts)
+        dict_of_paths = {str(path): val for path, val in Counter(path_contexts).items()}
         self._log.info("Extracted paths successfully")
 
         from pprint import pprint

--- a/src/extractors/paths.py
+++ b/src/extractors/paths.py
@@ -12,4 +12,4 @@ class UastPathsBagExtractor(BagsExtractor):
         self.uast2paths = Uast2BagOfPaths(max_length, max_width)
 
     def uast_to_bag(self, uast):
-        return {str(path): 1 for path in self.uast2paths(uast)}
+        return self.uast2paths(uast)


### PR DESCRIPTION
Konst added a fix because the tuple need to be stringified, but set the value to 1, even if the path was seen multiple times in the documents. This corrects that.